### PR TITLE
Added additional CoreDisplay patches for 10.13.4+

### DIFF
--- a/CoreDisplayFixup/IntelPatcher.hpp
+++ b/CoreDisplayFixup/IntelPatcher.hpp
@@ -15,7 +15,10 @@
 // binary
 extern UserPatcher::BinaryModInfo ADDPR(binaryModYosEC)[];
 extern UserPatcher::BinaryModInfo ADDPR(binaryModSieHS)[];
-extern const size_t ADDPR(binaryModSize);
+extern UserPatcher::BinaryModInfo ADDPR(binaryModHS1034)[];
+extern const size_t ADDPR(binaryModOldSize);
+extern const size_t ADDPR(binaryModHS1034Size);
+
 
 // process
 extern UserPatcher::ProcInfo ADDPR(procInfoYosEC)[];
@@ -25,7 +28,8 @@ extern const size_t ADDPR(procInfoSize);
 
 enum : uint32_t {
 	SectionYosEC   = 1,
-	SectionSieHS   = 2
+	SectionSieHS   = 2,
+	SectionHS1034  = 4
 };
 
 #endif /* IntelPatcher_hpp */

--- a/CoreDisplayFixup/kern_start.cpp
+++ b/CoreDisplayFixup/kern_start.cpp
@@ -22,7 +22,7 @@ static void intelPatcherStart()
 		lilu.onProcLoad(ADDPR(procInfoYosEC), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryModYosEC), ADDPR(binaryModOldSize));
 	else if (getKernelVersion() == KernelVersion::Sierra || (getKernelVersion() == KernelVersion::HighSierra && getKernelMinorVersion() < 5)) // 10.12, 10.13.0-10.13.3
 		lilu.onProcLoad(ADDPR(procInfoSieHS), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryModSieHS), ADDPR(binaryModOldSize));
-	else if (getKernelVersion() == KernelVersion::Sierra || (getKernelVersion() == KernelVersion::HighSierra && getKernelMinorVersion() >= 5)) // 10.13.4+
+	else if (getKernelVersion() == KernelVersion::HighSierra && getKernelMinorVersion() >= 5) // 10.13.4+
 		lilu.onProcLoad(ADDPR(procInfoSieHS), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryModHS1034), ADDPR(binaryModHS1034Size));
 }
 

--- a/CoreDisplayFixup/kern_start.cpp
+++ b/CoreDisplayFixup/kern_start.cpp
@@ -19,9 +19,11 @@ static void intelPatcherStart()
 {
 	// apply corresopnding patches
 	if (getKernelVersion() == KernelVersion::Yosemite || getKernelVersion() == KernelVersion::ElCapitan) // 10.10, 10.11
-		lilu.onProcLoad(ADDPR(procInfoYosEC), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryModYosEC), ADDPR(binaryModSize));
-	else if (getKernelVersion() == KernelVersion::Sierra || getKernelVersion() == KernelVersion::HighSierra) // 10.12, 10.13
-		lilu.onProcLoad(ADDPR(procInfoSieHS), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryModSieHS), ADDPR(binaryModSize));
+		lilu.onProcLoad(ADDPR(procInfoYosEC), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryModYosEC), ADDPR(binaryModOldSize));
+	else if (getKernelVersion() == KernelVersion::Sierra || (getKernelVersion() == KernelVersion::HighSierra && getKernelMinorVersion() < 5)) // 10.12, 10.13.0-10.13.3
+		lilu.onProcLoad(ADDPR(procInfoSieHS), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryModSieHS), ADDPR(binaryModOldSize));
+	else if (getKernelVersion() == KernelVersion::Sierra || (getKernelVersion() == KernelVersion::HighSierra && getKernelMinorVersion() >= 5)) // 10.13.4+
+		lilu.onProcLoad(ADDPR(procInfoSieHS), ADDPR(procInfoSize), nullptr, nullptr, ADDPR(binaryModHS1034), ADDPR(binaryModHS1034Size));
 }
 
 static void cdfStart()
@@ -30,13 +32,13 @@ static void cdfStart()
 	char tmp[16];
 	bool bootargIntelOFF = PE_parse_boot_argn("-cdfinteloff", tmp, sizeof(tmp));
 	bool bootargNVOFF    = PE_parse_boot_argn("-cdfnvoff", tmp, sizeof(tmp));
-	
+
 	if (!bootargIntelOFF) {
 		intelPatcherStart();
 	} else {
 		DBGLOG("cdf", "IntelPatcher is disabled by kernel flag -cdfinteloff");
 	}
-	
+
 	if (!bootargNVOFF) {
 		nvPatcherStart.init();
 	} else {


### PR DESCRIPTION
This is a simplified version of Floris497's version 4 patch:
https://github.com/Floris497/mac-pixel-clock-patch-V2/blob/64f7c7746e8434e59cf9c07e832caf74e965bf0e/CoreDisplay-patcher.command#L120

Tested on a Dell XPS 15 9560 (Intel HD 630 + 4K display) on 10.13.4.